### PR TITLE
Fixing bugs about TF_STATUS and exit code in GCE builder

### DIFF
--- a/postprocessor/gce_pp.sh
+++ b/postprocessor/gce_pp.sh
@@ -16,7 +16,7 @@ export TF_VAR_ssh_key="~/.ssh/id_rsa.pub"
 export TF_VAR_current_version=$CURRENT_VERSION
 
 #Launching GCE instance with terraform
-/tmp/terraform apply || TF_STATUS="$?"
+/tmp/terraform apply ; TF_STATUS="$?"
 
 #Destroying GCE instance with terraform
 /tmp/terraform destroy -force

--- a/postprocessor/gce_tf.sh
+++ b/postprocessor/gce_tf.sh
@@ -23,9 +23,3 @@ source /tmp/aws.sh
 
 echo "Uploading new image format into AWS S3 bucket: kubenow-us-east-1 ..."
 aws s3 cp kubenow-"$1".qcow2 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
-
-#Printing & checking awscli return code
-echo "Return code aws s3 copy: $?"
-
-#Exiting based on above return code
-exit $?


### PR DESCRIPTION
## Change content and motivation
Replacing https://github.com/kubenow/image/blob/master/postprocessor/gce_pp.sh#L19 with `/tmp/terraform apply ; TF_STATUS="$?"`. It is more robust, since as it is now `TF_STATUS="$?"` is executed only when terraform apply fails. The last `exit` works as expected because `exit` returns 0 if no argument is supplied.

Removing block: https://github.com/kubenow/image/blob/master/postprocessor/gce_tf.sh#L27-L31. We are incorrectly returning the `exit` code of the `echo` command, which have been forgotten as part of a debugging test.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** [fixes #199](https://github.com/kubenow/KubeNow/issues/199), [fixes #200](https://github.com/kubenow/KubeNow/issues/200)
