### PR TITLE
Updating README.md build status for pointing to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Collection of templates for building the KubeNow image.
 
-[![Build Status](https://travis-ci.org/kubenow/KubeNow.svg?branch=master)](https://travis-ci.org/kubenow/KubeNow)
+[![Build Status](https://travis-ci.org/kubenow/image.svg?branch=master)](https://travis-ci.org/kubenow/image)
 
 ## Image Building
 


### PR DESCRIPTION
<!-- 
Thanks for sending a Pull Request (PR)! Please use this template to facilitate the review/merge process. 

WARNING!!! Make sure that the PR fullfills the review criteria before submitting:

POSITIVES
- Change has already been discussed and is known to committers (open an issue first otherwise)
- Has a nice, self-explanatory title
- Fixes the root cause of a bug in existing functionality
- Adds functionality or fixes a problem needed by a large number of users
- Simple, targeted
- Easily tested; has tests
- Reduces complexity and lines of code

NEGATIVES
- Makes lots of modifications in one "big bang" change
- Band-aids a symptom of a bug only
- Introduces complex new functionality
- Adds complexity that only helps a niche use case
- Adds user-space functionality that does not need to be maintained in KubeNow, but could be hosted externally 
- Adds large dependencies
- Changes versions of existing dependencies
- Adds a large amount of code
-->

## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->
As per request in https://github.com/kubenow/KubeNow/issues/222, README.MD building status pointer has been corrected in order to point to Image CI and not to main repo.

Basically only last word of line n°5 has been revised
## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** <!-- fixes #X, fixes #Y, ... fixes #Z -->
fixes [#222](https://github.com/kubenow/KubeNow/issues/222)
<!-- 
please add documentation for your feature (if applicable), and link the documentation changes. 
Documentation PRs are to be sent to https://github.com/kubenow/docs.
-->
