### PR TITLE
Updating README with Azure storage [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Collection of templates for building the KubeNow image.
 
 KubeNow uses prebuilt images to speed up the deployment. Image continous integration is defined in this repository: https://github.com/kubenow/image.
 
-The images are exported on AWS and GCE:
+The images are exported on GCE, AWS and Azure:
 
 - `https://storage.googleapis.com/kubenow-images/kubenow-v<version-without-dots>.tar.gz`
 - `https://s3.amazonaws.com/kubenow-us-east-1/kubenow-v<version-without-dots>.qcow2`
+- `https://kubenow.blob.core.windows.net/system?restype=container&comp=list`
 
 Please refer to this page to figure out the image version: https://github.com/kubenow/image/releases. It is important to point out that the image versioning is now disjoint from the main KubeNow repository versioning. The main reason lies in the fact that pre-built images require less revisions and updates compared to the main KubeNow package.


### PR DESCRIPTION
Updating README by adding Azure storage entry:

- https://kubenow.blob.core.windows.net/system?restype=container&comp=list

**Fixes:** https://github.com/kubenow/KubeNow/issues/258