### PR TITLE
Fixing possible issue with -force option for Azure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: python
+language: go # Packer & Terraform
 
 sudo: required
 
@@ -9,8 +9,8 @@ env:
     # Workaround to build on google - See https://github.com/travis-ci/travis-ci/issues/7940
     - BOTO_CONFIG=/dev/null
   matrix:
-    #- HOST_CLOUD=gce
-    #- HOST_CLOUD=aws
+    - HOST_CLOUD=gce
+    - HOST_CLOUD=aws
     - HOST_CLOUD=openstack
     - HOST_CLOUD=azure
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     # Workaround to build on google - See https://github.com/travis-ci/travis-ci/issues/7940
     - BOTO_CONFIG=/dev/null
   matrix:
-    - HOST_CLOUD=gce
+    #- HOST_CLOUD=gce
     #- HOST_CLOUD=aws
     - HOST_CLOUD=openstack
     - HOST_CLOUD=azure
@@ -106,6 +106,16 @@ before_script:
       --project phenomenal-1145 -q
 
 script:
+  # Packer -force for Azure and Openstack does not automatically remove the artifacts from previous build.
+  - >
+    if [ "$HOST_CLOUD" = 'azure' ]; then
+        bin/clean_az_dupl.sh
+    elif [ "$HOST_CLOUD" = 'openstack' ]; then
+        bin/clean_os_dupl.sh
+    else
+        echo -e "Variable HOST_CLOUD not set\n"
+    fi
+
   # Finally bulding the image with packer
   - travis_retry /tmp/packer build -force build-"$HOST_CLOUD".json
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ sudo: required
 env:
   global:
     - TERRAFORM_VERSION=0.9.4
-    - PACKER_VERSION=1.0.0
+    - PACKER_VERSION=1.1.2
     # Workaround to build on google - See https://github.com/travis-ci/travis-ci/issues/7940
     - BOTO_CONFIG=/dev/null
   matrix:
     - HOST_CLOUD=gce
-    - HOST_CLOUD=aws
+    #- HOST_CLOUD=aws
     - HOST_CLOUD=openstack
     - HOST_CLOUD=azure
 
@@ -85,7 +85,8 @@ install:
 before_script:
   # Get current_version, variable common to all three platforms
   - source ./bin/get_current_version.sh
-  - export IMAGE_NAME="$IMAGE_NAME""$CURRENT_VERSION"
+  - IMAGE_NAME="$IMAGE_NAME""$CURRENT_VERSION" && export IMAGE_NAME
+  - echo "Image Name is:" && echo $IMAGE_NAME
 
   # Common travis ssh directory for all providers
   - mkdir -p ~/.ssh/ && cp keys/id_rsa.pub ~/.ssh/id_rsa.pub
@@ -113,5 +114,6 @@ after_success:
   # In order to avoid running Terraform within Packer, hence getting a cumbersome and tedious log output.
   - >
     if [ $HOST_CLOUD = 'openstack' ]; then
-        travis_retry bin/os_pp.sh
+        #travis_retry bin/os_pp.sh
+        bin/os_pp.sh
     fi

--- a/bin/clean_az_dupl.sh
+++ b/bin/clean_az_dupl.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Installing Azure command-line client
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
+     sudo tee /etc/apt/sources.list.d/azure-cli.list
+
+sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+
+sudo apt-get update && sudo apt-get install apt-transport-https azure-cli -y
+
+#Azure
+CMD_OUTPUT_FMT="table"
+
+echo -e "AZURE:\n-----"
+az login --service-principal \
+         -u "$AZURE_CLIENT_ID" \
+         -p "$AZURE_CLIENT_SECRET" \
+         --tenant "$AZURE_TENANT_ID" \
+         --output "$CMD_OUTPUT_FMT"
+
+echo -e "-----------  -----------  ---------------------------  -------  ------------------------------------\n"
+echo -e "Check if $IMAGE_NAME already exists:\n"
+# Extracting KubeNow images that are flagged as $IMAGE_NAME
+az storage blob list --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$AZURE_CONTAINER_NAME" --query [].name --output tsv | grep "$IMAGE_NAME" | grep '.vhd' | tee /tmp/az_out_images.txt
+
+tot_no_images=$(wc -l < /tmp/az_out_images.txt)
+counter_del_img=0
+
+if [ "$tot_no_images" -gt "0" ]; then
+
+    echo -e "\nDuplicated images found:\n" 
+
+    # Going through found duplicates in order to delete them
+    while read -r line; do  
+        name=$(echo "$line" | grep "$IMAGE_NAME")
+
+        # Because of files' names convention between a vhd file and its related vmTemplate json
+        rel_json_blob="${line/osDisk/vmTemplate}"
+        rel_json_blob="${rel_json_blob/.vhd/.json}"        
+
+        # Deleting old KubeNow Image
+        echo -e "Starting to delete duplicate KubeNow image: $name\n"
+        az storage blob delete --account-name "$AZURE_STORAGE_ACCOUNT" -c "$AZURE_CONTAINER_NAME" -n "$line"
+
+        # If related json blob does not exist, then will simply skip this step. Otherwise it must be deleted as well
+        if [ -n "$rel_json_blob" ]; then
+            az storage blob delete --account-name "$AZURE_STORAGE_ACCOUNT" -c "$AZURE_CONTAINER_NAME" -n "$rel_json_blob"
+            echo -e "Starting to delete related json blob: $rel_json_blob\n"
+        fi
+
+        counter_del_img=$((counter_del_img+1))
+        echo -e "Keep looking for any other duplicate image...\n\n"
+    done < /tmp/az_out_images.txt
+else
+    echo -e "No KubeNow images named $IMAGE_NAME were found."
+fi
+
+echo -e "\nNo of deleted image: $counter_del_img\nDone.\n"

--- a/bin/clean_az_dupl.sh
+++ b/bin/clean_az_dupl.sh
@@ -1,15 +1,20 @@
 #!/usr/bin/env bash
 
-# Exit immediately if a command exits with a non-zero status
-set -e
+# Related to bug fix: https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
+sudo aptitude upgrade dpkg -y
 
 # Installing Azure command-line client
-echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | \
-     sudo tee /etc/apt/sources.list.d/azure-cli.list
+echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+sudo apt-get install apt-transport-https
+sudo apt-get update && sudo apt-get install azure-cli -y
 
-sudo apt-get update && sudo apt-get install apt-transport-https azure-cli -y
+# Exit immediately if a command exits with a non-zero status
+# Usually this is set at the beginning of the script. But due to bug:
+# https://bugs.launchpad.net/ubuntu/+source/dpkg/+bug/1730627
+# this need to be temporarily displaced
+set -e
 
 #Azure
 CMD_OUTPUT_FMT="table"

--- a/bin/clean_os_dupl.sh
+++ b/bin/clean_os_dupl.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Fix OS issue/bug: "sudo: unable to resolve host..."
+sudo sed -i /etc/hosts -e "s/^127.0.0.1 localhost$/127.0.0.1 localhost $(hostname)/"
+
+# Installing necessary tool for the script: python-glanceclient
+sudo pip install --upgrade python-glanceclient
+
+echo -e "OPENSTACK\n---------"
+echo -e "Check if $IMAGE_NAME already exists:\n"
+
+# Extracting KubeNow images that are flagged as $IMAGE_NAME
+# Using tee (which almost always return 0) because of set -e at the beginning and possible grep's exit code -1 here.
+glance image-list | grep "$IMAGE_NAME" | awk '{print $2, $4}' | tee /tmp/os_out_images.txt
+
+tot_no_images=$(wc -l < /tmp/os_out_images.txt)
+counter_del_img=0
+
+if [ "$tot_no_images" -gt "0" ]; then
+    
+    echo -e "\nDuplicated images found:\n" 
+    
+    # Going through found duplicates in order to delete them
+    while read -r line; do
+        # Extracting image's "Name" and "ImageId"
+        id_to_delete=$(echo "$line" | awk '{print $1}')
+        name=$(echo "$line" | awk '{print $2}')
+        echo -e "Name: $name \nID:$id_to_delete\n"           
+
+        # Deleting old KubeNow Image
+        echo -e "Starting to delete duplicate KubeNow image: $id_to_delete.\n"
+        glance image-delete "$id_to_delete"
+        counter_del_img=$((counter_del_img+1))
+        echo -e "Keep looking for any other duplicate image...\n\n"
+    done < /tmp/os_out_images.txt
+    
+else
+    echo -e "No KubeNow images named $IMAGE_NAME were found.\n"
+fi
+
+echo -e "\nNo of deleted image: $counter_del_img\nDone.\n"

--- a/bin/os_tf.sh
+++ b/bin/os_tf.sh
@@ -32,10 +32,10 @@ md5sum "$kubenow_image_name".qcow2 > "$kubenow_image_name".qcow2.md5
 
 # Uploading the new image format to the AWS S3 bucket. Previous copy will be overwritten.
 echo "Uploading new image format into AWS S3 bucket: kubenow-us-east-1 ..."
-aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-us-east-1 --region us-east-1 --acl public-read
-aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-us-east-1 --region us-east-1 --acl public-read
+aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
+aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
 
 # Copy file to bucket in other aws region
 echo "Copying new image format into AWS S3 bucket: kubenow-us-central-1 ..."
-aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
-aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
+aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read --quiet
+aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read --quiet

--- a/bin/os_tf.sh
+++ b/bin/os_tf.sh
@@ -37,8 +37,5 @@ aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-us-east-1 --region us-eas
 
 # Copy file to bucket in other aws region
 echo "Copying new image format into AWS S3 bucket: kubenow-us-central-1 ..."
-#aws s3 cp "s3://kubenow-us-east-1/$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
-#aws s3 cp "s3://kubenow-us-east-1/$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
-# Sometimes it seems to fail cause s3://kubenow-us-east-1/$kubenow_image_name".qcow2 is not ready/available, it tooks some time
 aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
 aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read

--- a/bin/os_tf.sh
+++ b/bin/os_tf.sh
@@ -32,9 +32,13 @@ md5sum "$kubenow_image_name".qcow2 > "$kubenow_image_name".qcow2.md5
 
 # Uploading the new image format to the AWS S3 bucket. Previous copy will be overwritten.
 echo "Uploading new image format into AWS S3 bucket: kubenow-us-east-1 ..."
-aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
-aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
+aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-us-east-1 --region us-east-1 --acl public-read
+aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-us-east-1 --region us-east-1 --acl public-read
 
 # Copy file to bucket in other aws region
-aws s3 cp "s3://kubenow-us-east-1/$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
-aws s3 cp "s3://kubenow-us-east-1/$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
+echo "Copying new image format into AWS S3 bucket: kubenow-us-central-1 ..."
+#aws s3 cp "s3://kubenow-us-east-1/$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
+#aws s3 cp "s3://kubenow-us-east-1/$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
+# Sometimes it seems to fail cause s3://kubenow-us-east-1/$kubenow_image_name".qcow2 is not ready/available, it tooks some time
+aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read
+aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read


### PR DESCRIPTION
## Change content and motivation
<!-- please describe briefly the content of this PR, and motivate why this changes are needed -->
Both Azure's and Openstack's builders do not restrict having images with same name since IDs act as unique identifier. Thus it is allowed to have two images with the same name, but different IDs. This feature defeats the purpose of the `packer -force` option while building images.

This PR introduces two snippets of code for both Openstack and Azure that quickly check  whether or not a namesake image already exists before re/building the image.

## GitHub cross-links 
<!-- 
please list the issues that are going to be fixed by this PR (if applicable). 
Use the suggested format to facilitate issue closing. 
-->
**Fixes:** https://github.com/kubenow/KubeNow/issues/283 