### PR TITLE
Support for k8s 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
 
   # Check Shell
   - shellcheck $(find . -type f -name "*.sh")
-  # - docker run -v "$(pwd)":/sh -w /sh jamesmstone/shfmt -i 2 -w bin/*.sh
+  - docker run -v "$(pwd)":/sh -w /sh jamesmstone/shfmt -i 2 -w bin/*.sh
   - git diff --exit-code
 
   # Check YAML

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
 
   # Check Shell
   - shellcheck $(find . -type f -name "*.sh")
-  - docker run -v "$(pwd)":/sh -w /sh jamesmstone/shfmt -i 2 -w bin/*.sh
+  # - docker run -v "$(pwd)":/sh -w /sh jamesmstone/shfmt -i 2 -w bin/*.sh
   - git diff --exit-code
 
   # Check YAML

--- a/requirements.sh
+++ b/requirements.sh
@@ -52,7 +52,7 @@ sudo apt-get install -y \
   jq
 
 # Helm
-HELM_TGZ=helm-v2.6.1-linux-amd64.tar.gz
+HELM_TGZ=helm-v2.8.0-linux-amd64.tar.gz
 wget -P /tmp/ https://kubernetes-helm.storage.googleapis.com/$HELM_TGZ
 tar -xf /tmp/$HELM_TGZ -C /tmp/
 sudo mv /tmp/linux-amd64/helm /usr/local/bin/

--- a/requirements.sh
+++ b/requirements.sh
@@ -72,7 +72,7 @@ echo "Pulling required Docker images..."
 kube_version="v1.9.2"
 kube_dns_version="1.14.5"
 etcd_version="3.1.11"
-flannel_version="v0.9.0"
+flannel_version="v0.9.1"
 sudo docker pull gcr.io/google_containers/kube-apiserver-amd64:$kube_version
 sudo docker pull gcr.io/google_containers/kube-proxy-amd64:$kube_version
 sudo docker pull gcr.io/google_containers/kube-controller-manager-amd64:$kube_version

--- a/requirements.sh
+++ b/requirements.sh
@@ -35,7 +35,7 @@ sudo DEBIAN_FRONTEND=noninteractive \
 
 echo "Installing Kubernetes requirements..."
 sudo apt-get install -y \
-  docker-engine=1.12.5-0~ubuntu-xenial \
+  docker-engine=1.13.1-0~ubuntu-xenial \
   kubernetes-cni=0.6.0-00 \
   kubeadm=1.9.2-00 \
   kubelet=1.9.2-00 \
@@ -71,7 +71,7 @@ echo "Pulling required Docker images..."
 # https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/kubedns-controller.yaml.base (kube-dns-version)
 kube_version="v1.9.2"
 kube_dns_version="1.14.5"
-etcd_version="3.0.17"
+etcd_version="3.1.11"
 flannel_version="v0.9.0"
 sudo docker pull gcr.io/google_containers/kube-apiserver-amd64:$kube_version
 sudo docker pull gcr.io/google_containers/kube-proxy-amd64:$kube_version

--- a/requirements.sh
+++ b/requirements.sh
@@ -36,10 +36,10 @@ sudo DEBIAN_FRONTEND=noninteractive \
 echo "Installing Kubernetes requirements..."
 sudo apt-get install -y \
   docker-engine=1.12.5-0~ubuntu-xenial \
-  kubernetes-cni=0.5.1-00 \
-  kubeadm=1.7.5-00 \
-  kubelet=1.7.5-00 \
-  kubectl=1.7.5-00
+  kubernetes-cni=0.6.0-00 \
+  kubeadm=1.9.2-00 \
+  kubelet=1.9.2-00 \
+  kubectl=1.9.2-00
 
 echo "Installing other requirements..."
 # APT requirements
@@ -69,7 +69,7 @@ echo "Pulling required Docker images..."
 # Essential Kubernetes containers are listed in following files:
 # https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/constants/constants.go (etcd-version)
 # https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/kubedns-controller.yaml.base (kube-dns-version)
-kube_version="v1.7.5"
+kube_version="v1.9.2"
 kube_dns_version="1.14.5"
 etcd_version="3.0.17"
 flannel_version="v0.9.0"

--- a/requirements.sh
+++ b/requirements.sh
@@ -52,7 +52,7 @@ sudo apt-get install -y \
   jq
 
 # Helm
-HELM_TGZ=helm-v2.8.0-linux-amd64.tar.gz
+HELM_TGZ=helm-v2.6.1-linux-amd64.tar.gz
 wget -P /tmp/ https://kubernetes-helm.storage.googleapis.com/$HELM_TGZ
 tar -xf /tmp/$HELM_TGZ -C /tmp/
 sudo mv /tmp/linux-amd64/helm /usr/local/bin/


### PR DESCRIPTION
This PR includes changes regarding the k8s version we use on KubeNow.