### PR TITLE
New Features for CronJob about Security-Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ env:
     - ANSIBLE_LINT_VERSION=3.4.15
     - YAMLLINT_VERSION=1.8.1
   matrix:
-    - HOST_CLOUD=gce
-    - HOST_CLOUD=aws
+    # - HOST_CLOUD=gce
+    # - HOST_CLOUD=aws
     - HOST_CLOUD=openstack
-    - HOST_CLOUD=azure
+    # - HOST_CLOUD=azure
 
 addons:
   apt:
@@ -94,7 +94,7 @@ install:
       sudo apt-key add -
 
   # Update the package list and install the Cloud SDK
-  - sudo apt-get update
+  - sudo apt-get -qq update
   - sudo apt-get install google-cloud-sdk -y
 
 before_script:
@@ -130,14 +130,14 @@ script:
     else
         echo -e "Variable HOST_CLOUD not set\n"
     fi
-  
+
   # Check whether this build was triggered by our cron job for security-updates
-  # Forcing Travis to think that this was a cron job (only for testing)
-  # - export TRAVIS_EVENT_TYPE="cron"
+  - TRAVIS_EVENT_TYPE="cron" && export TRAVIS_EVENT_TYPE
+  - echo "TRAVIS_EVENT_TYPE is:" && echo $TRAVIS_EVENT_TYPE
   - >
-    if ["$TRAVIS_EVENT_TYPE" = 'cron']; then
+    if [ "$TRAVIS_EVENT_TYPE" = 'cron' ]; then
         echo -e "Travis built triggered via configured cron job.\n"
-        bin/cron_script.sh
+        source bin/cron_script.sh
     fi
 
   # Finally bulding the image with packer
@@ -148,7 +148,9 @@ after_success:
   # In order to avoid running Terraform within Packer, hence getting a cumbersome and tedious log output.
   - >
     if [ $HOST_CLOUD = 'openstack' ]; then
-        travis_retry bin/os_pp.sh
+        # travis_retry bin/os_pp.sh
+        echo "Just a printf for testing"
+        echo $OS_SOURCE_IMAGE_NAME
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,15 @@ script:
     else
         echo -e "Variable HOST_CLOUD not set\n"
     fi
+  
+  # Check whether this build was triggered by our cron job for security-updates
+  # Forcing Travis to think that this was a cron job (only for testing)
+  # - export TRAVIS_EVENT_TYPE="cron"
+  - >
+    if ["$TRAVIS_EVENT_TYPE" = 'cron']; then
+        echo -e "Travis built triggered via configured cron job.\n"
+        bin/cron_script.sh
+    fi
 
   # Finally bulding the image with packer
   - travis_retry /tmp/packer build -force build-"$HOST_CLOUD".json
@@ -139,8 +148,7 @@ after_success:
   # In order to avoid running Terraform within Packer, hence getting a cumbersome and tedious log output.
   - >
     if [ $HOST_CLOUD = 'openstack' ]; then
-        #travis_retry bin/os_pp.sh
-        bin/os_pp.sh
+        travis_retry bin/os_pp.sh
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ env:
     - ANSIBLE_LINT_VERSION=3.4.15
     - YAMLLINT_VERSION=1.8.1
   matrix:
-    # - HOST_CLOUD=gce
-    # - HOST_CLOUD=aws
+    - HOST_CLOUD=gce
+    - HOST_CLOUD=aws
     - HOST_CLOUD=openstack
-    # - HOST_CLOUD=azure
+    - HOST_CLOUD=azure
 
 addons:
   apt:
@@ -128,15 +128,14 @@ script:
     elif [ "$HOST_CLOUD" = 'openstack' ]; then
         bin/clean_os_dupl.sh
     else
-        echo -e "Variable HOST_CLOUD not set\n"
+        echo "Variable HOST_CLOUD not set."
     fi
 
   # Check whether this build was triggered by our cron job for security-updates
-  - TRAVIS_EVENT_TYPE="cron" && export TRAVIS_EVENT_TYPE
-  - echo "TRAVIS_EVENT_TYPE is:" && echo $TRAVIS_EVENT_TYPE
+  - echo "TRAVIS_EVENT_TYPE is:$TRAVIS_EVENT_TYPE"
   - >
     if [ "$TRAVIS_EVENT_TYPE" = 'cron' ]; then
-        echo -e "Travis built triggered via configured cron job.\n"
+        echo "Travis built triggered via configured cron job"
         source bin/cron_script.sh
     fi
 
@@ -148,9 +147,7 @@ after_success:
   # In order to avoid running Terraform within Packer, hence getting a cumbersome and tedious log output.
   - >
     if [ $HOST_CLOUD = 'openstack' ]; then
-        # travis_retry bin/os_pp.sh
-        echo "Just a printf for testing"
-        echo $OS_SOURCE_IMAGE_NAME
+        travis_retry bin/os_pp.sh
     fi
 
 notifications:

--- a/bin/clean_az_dupl.sh
+++ b/bin/clean_az_dupl.sh
@@ -7,8 +7,8 @@ sudo aptitude upgrade dpkg -y
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 
 sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
-sudo apt-get install apt-transport-https
-sudo apt-get update && sudo apt-get install azure-cli -y
+sudo apt-get -qq install apt-transport-https -y
+sudo apt-get -qq update && sudo apt-get install azure-cli -y
 
 # Exit immediately if a command exits with a non-zero status
 # Usually this is set at the beginning of the script. But due to bug:

--- a/bin/cron_script.sh
+++ b/bin/cron_script.sh
@@ -10,59 +10,57 @@ set -e
 
 # Setting attribute source image name to the right value for each cloud provider
 if [ "$HOST_CLOUD" = 'aws' ]; then
-    echo -e "Running AWS Packer builder...\n"
-    
-    # Installing aws-cli
-    pip install awscli --upgrade --user
-    
-    # Extracting ami ID of latest kubenow stable (usually in the format of "ImageId:" "ami-xxxxxxx",)
-    kubenow_latest_amiId=$(aws ec2 describe-images --filters "Name=name,Values=kubenow-v$SUPPORTED_STABLE_TAG" "Name=owner-id,Values=105135433346" \
-    | grep "ImageId" \
-    | awk '{ print $2 }' \
-    | sed -e 's/^"//' -e 's/",$//' )
-    
-    # Check whether or not id string is empty
-    if [ -n "$kubenow_latest_amiId" ]; then
-        # Updating source image id that will be used for AWS packer builder
-        echo -e "Kubenow latest stable ami ID is: $kubenow_latest_amiId .\n"
-        export AWS_SOURCE_IMAGE_ID="$kubenow_latest_amiId"
-        echo -e "AWS Source Image ID is: $AWS_SOURCE_IMAGE_ID\n"
-    
-    else
-        echo -e "No AWS images named kubenow-v$SUPPORTED_STABLE_TAG have been found.\nInterrupting building.\n"
-        exit 1
+  echo -e "Running AWS Packer builder...\n"
 
-    fi
+  # Installing aws-cli
+  pip install awscli --upgrade
+
+  # Extracting ami ID of latest kubenow stable (usually in the format of "ImageId:" "ami-xxxxxxx",)
+  kubenow_latest_amiId=$(aws ec2 describe-images --filters "Name=name,Values=kubenow-v$SUPPORTED_STABLE_TAG" "Name=owner-id,Values=105135433346" |
+    grep "ImageId" |
+    awk '{ print $2 }' |
+    sed -e 's/^"//' -e 's/",$//')
+
+  # Check whether or not id string is empty
+  if [ -n "$kubenow_latest_amiId" ]; then
+    # Updating source image id that will be used for AWS packer builder
+    echo -e "Kubenow latest stable ami ID is: $kubenow_latest_amiId .\n"
+    export AWS_SOURCE_IMAGE_ID="$kubenow_latest_amiId"
+    echo -e "AWS Source Image ID is: $AWS_SOURCE_IMAGE_ID\n"
+
+  else
+    echo -e "No AWS images named kubenow-v$SUPPORTED_STABLE_TAG have been found.\nInterrupting building.\n"
+    exit 1
+
+  fi
 
 elif [ "$HOST_CLOUD" = 'azure' ]; then
-    echo -e "Running Azure Packer builder...\n"
-    
-    # Performing login for azure-cli (which is already installed, see .travis.yml)
-    az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" --output "table"
+  echo -e "Running Azure Packer builder...\n"
 
-    # Instead of block with Image attibutes (image_publisher, image_offer, image_sku, and/or image_version.), we
-    # pass only a URL to a custom VHD to use. First we remove block of not needed lines from build-azure.json
-    sed -e '/image_publisher/,+3d' build-azure.json > /tmp/modified-build-azure.json
-    
-    # Searching and composing URL of to a custom VHD to use, i.e. the latest kubenow stable image
-    vhd_name=$(az storage blob list --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$AZURE_CONTAINER_NAME" --query [].name --output tsv | grep "kubenow-v$SUPPORTED_STABLE_TAG" | grep '.vhd')
-    kn_vhd_url="https://kubenow.blob.core.windows.net/system/$vhd_name"
-    
-    # Finally, inserting image_url attribute in build-azure.json
-    sed '/os_type/a \         "image_url": "'"$kn_vhd_url"'", ' build-azure.json > /tmp/modified-build-azure.json
-    cat /tmp/modified-build-azure.json > build-azure.json
+  # Performing login for azure-cli (which is already installed, see .travis.yml)
+  az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" --output "table"
+
+  # Instead of block with Image attibutes (image_publisher, image_offer, image_sku, and/or image_version.), we
+  # pass only a URL to a custom VHD to use. First we remove block of not needed lines from build-azure.json
+  sed -i -e '/image_publisher/,+3d' build-azure.json
+
+  # Searching and composing URL of to a custom VHD to use, i.e. the latest kubenow stable image
+  vhd_name=$(az storage blob list --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$AZURE_CONTAINER_NAME" --query [].name --output tsv | grep "kubenow-v$SUPPORTED_STABLE_TAG" | grep '.vhd')
+  kn_vhd_url="https://kubenow.blob.core.windows.net/system/$vhd_name"
+
+  # Finally, inserting image_url attribute in build-azure.json
+  sed -i -e '/os_type/a \         "image_url": "'"$kn_vhd_url"'", ' build-azure.json
 
 elif [ "$HOST_CLOUD" = 'gce' ]; then
-    echo -e "Running GCE Packer builder...\n"
-    export GCE_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
-    echo -e "GCE Source Image Name is: $GCE_SOURCE_IMAGE_NAME\n"
+  echo -e "Running GCE Packer builder...\n"
+  export GCE_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
 
 elif [ "$HOST_CLOUD" = 'openstack' ]; then
-    echo -e "Running Openstack Packer builder...\n"
-    export OS_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
+  echo -e "Running Openstack Packer builder...\n"
+  export OS_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
 
 else
-    echo -e "Variable HOST_CLOUD is NOT set to one of the following values: aws, azure, gce, openstack .\n"
+  echo -e "Variable HOST_CLOUD is NOT set to one of the following values: aws, azure, gce, openstack .\n"
 
 fi
 
@@ -70,5 +68,5 @@ fi
 # Given that we are starting from a stable kubenow image, we do not want to reinstall the requirements, rather to perform security updates
 sed -i -e 's|requirements.sh|bin/get_security_updates.sh|g' build-"$HOST_CLOUD".json
 
-# Print to output the builder json (mainly for testing, can be removed if output too verbose in .travis.yaml)
-cat build-"$HOST_CLOUD".json
+# Displaying the builder json (mainly as a visual test, can be removed if output too verbose in .travis.yaml)
+# cat build-"$HOST_CLOUD".json

--- a/bin/cron_script.sh
+++ b/bin/cron_script.sh
@@ -27,13 +27,10 @@ if [ "$HOST_CLOUD" = 'aws' ]; then
     echo -e "Kubenow latest stable ami ID is: $kubenow_latest_amiId .\n"
     export AWS_SOURCE_IMAGE_ID="$kubenow_latest_amiId"
     echo -e "AWS Source Image ID is: $AWS_SOURCE_IMAGE_ID\n"
-
   else
     echo -e "No AWS images named kubenow-v$SUPPORTED_STABLE_TAG have been found.\nInterrupting building.\n"
     exit 1
-
   fi
-
 elif [ "$HOST_CLOUD" = 'azure' ]; then
   echo -e "Running Azure Packer builder...\n"
 
@@ -50,23 +47,16 @@ elif [ "$HOST_CLOUD" = 'azure' ]; then
 
   # Finally, inserting image_url attribute in build-azure.json
   sed -i -e '/os_type/a \         "image_url": "'"$kn_vhd_url"'", ' build-azure.json
-
 elif [ "$HOST_CLOUD" = 'gce' ]; then
   echo -e "Running GCE Packer builder...\n"
   export GCE_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
-
 elif [ "$HOST_CLOUD" = 'openstack' ]; then
   echo -e "Running Openstack Packer builder...\n"
   export OS_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
-
 else
   echo -e "Variable HOST_CLOUD is NOT set to one of the following values: aws, azure, gce, openstack .\n"
-
 fi
 
 # Last but not least, replacing the script attribute in the provisioner section to a different value than default one (i.e. requirements.sh)
 # Given that we are starting from a stable kubenow image, we do not want to reinstall the requirements, rather to perform security updates
 sed -i -e 's|requirements.sh|bin/get_security_updates.sh|g' build-"$HOST_CLOUD".json
-
-# Displaying the builder json (mainly as a visual test, can be removed if output too verbose in .travis.yaml)
-# cat build-"$HOST_CLOUD".json

--- a/bin/cron_script.sh
+++ b/bin/cron_script.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# GENERAL IDEA for this cron script: we want to make sure that every time security updates are issued,
+# then building of a new kubenow image release is triggered.
+# This script will perform the necessary modifications in order to use the latest stable kubenow image
+# as source image for our packer builders and run security updates
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Setting attribute source image name to the right value for each cloud provider
+if [ "$HOST_CLOUD" = 'aws' ]; then
+    echo -e "Running AWS Packer builder...\n"
+    
+    # Installing aws-cli
+    pip install awscli --upgrade --user
+    
+    # Extracting ami ID of latest kubenow stable (usually in the format of "ImageId:" "ami-xxxxxxx",)
+    kubenow_latest_amiId=$(aws ec2 describe-images --filters "Name=name,Values=kubenow-v$SUPPORTED_STABLE_TAG" "Name=owner-id,Values=105135433346" \
+    | grep "ImageId" \
+    | awk '{ print $2 }' \
+    | sed -e 's/^"//' -e 's/",$//' )
+    
+    # Check whether or not id string is empty
+    if [ -n "$kubenow_latest_amiId" ]; then
+        # Updating source image id that will be used for AWS packer builder
+        echo -e "Kubenow latest stable ami ID is: $kubenow_latest_amiId .\n"
+        export AWS_SOURCE_IMAGE_ID="$kubenow_latest_amiId"
+        echo -e "AWS Source Image ID is: $AWS_SOURCE_IMAGE_ID\n"
+    
+    else
+        echo -e "No AWS images named kubenow-v$SUPPORTED_STABLE_TAG have been found.\nInterrupting building.\n"
+        exit 1
+
+    fi
+
+elif [ "$HOST_CLOUD" = 'azure' ]; then
+    echo -e "Running Azure Packer builder...\n"
+    
+    # Performing login for azure-cli (which is already installed, see .travis.yml)
+    az login --service-principal -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" --output "table"
+
+    # Instead of block with Image attibutes (image_publisher, image_offer, image_sku, and/or image_version.), we
+    # pass only a URL to a custom VHD to use. First we remove block of not needed lines from build-azure.json
+    sed -e '/image_publisher/,+3d' build-azure.json > /tmp/modified-build-azure.json
+    
+    # Searching and composing URL of to a custom VHD to use, i.e. the latest kubenow stable image
+    vhd_name=$(az storage blob list --account-name "$AZURE_STORAGE_ACCOUNT" --container-name "$AZURE_CONTAINER_NAME" --query [].name --output tsv | grep "kubenow-v$SUPPORTED_STABLE_TAG" | grep '.vhd')
+    kn_vhd_url="https://kubenow.blob.core.windows.net/system/$vhd_name"
+    
+    # Finally, inserting image_url attribute in build-azure.json
+    sed '/os_type/a \         "image_url": "'"$kn_vhd_url"'", ' build-azure.json > /tmp/modified-build-azure.json
+    cat /tmp/modified-build-azure.json > build-azure.json
+
+elif [ "$HOST_CLOUD" = 'gce' ]; then
+    echo -e "Running GCE Packer builder...\n"
+    export GCE_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
+    echo -e "GCE Source Image Name is: $GCE_SOURCE_IMAGE_NAME\n"
+
+elif [ "$HOST_CLOUD" = 'openstack' ]; then
+    echo -e "Running Openstack Packer builder...\n"
+    export OS_SOURCE_IMAGE_NAME="kubenow-v$SUPPORTED_STABLE_TAG"
+
+else
+    echo -e "Variable HOST_CLOUD is NOT set to one of the following values: aws, azure, gce, openstack .\n"
+
+fi
+
+# Last but not least, replacing the script attribute in the provisioner section to a different value than default one (i.e. requirements.sh)
+# Given that we are starting from a stable kubenow image, we do not want to reinstall the requirements, rather to perform security updates
+sed -i -e 's|requirements.sh|bin/get_security_updates.sh|g' build-"$HOST_CLOUD".json
+
+# Print to output the builder json (mainly for testing, can be removed if output too verbose in .travis.yaml)
+cat build-"$HOST_CLOUD".json

--- a/bin/get_security_updates.sh
+++ b/bin/get_security_updates.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # GENERAL IDEA:
-# 
+#
 # We want to make sure that every time security updates are issued,
 # then building of a new kubenow image release is triggered.
 # Perhaps running a daily or weekly cron job could be the best frequence.
@@ -11,19 +11,19 @@ set -e
 
 # Update repos and make a dry run for unattended-upgrades to evaluate whether
 # there are new security updates
-sudo apt-get update
+sudo apt-get update -q
 echo -e "Executing a dry-run for unattended-upgrades...\n"
 upgrades_status=$(sudo unattended-upgrades --dry-run -d | grep "All upgrades installed" | tee dry-run_log.txt)
 
 # Check unattended-upgrade output to evaluate if any updates are available
 if [ -z "$upgrades_status" ]; then
-    echo -e "No packages found that can be upgraded unattended and no pending auto-removals\n"
+  echo -e "No packages found that can be upgraded unattended and no pending auto-removals\n"
 
 elif [ -n "$upgrades_status" ] && [ "$upgrades_status" == "All upgrades installed" ]; then
-    echo -e "\nNew Security Updates Are Available. Proceeding to install them...\n"
-    sudo unattended-upgrades -d
+  echo -e "\nNew Security Updates Are Available. Proceeding to install them...\n"
+  sudo unattended-upgrades
 
 else
-    echo -e "Something went wrong while checking wheter unattended upgrades are available or not. Manual intervention is required.\n"
+  echo -e "Something went wrong while checking wheter unattended upgrades are available or not. Manual intervention is required.\n"
 
 fi

--- a/bin/get_security_updates.sh
+++ b/bin/get_security_updates.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# GENERAL IDEA:
+# 
+# We want to make sure that every time security updates are issued,
+# then building of a new kubenow image release is triggered.
+# Perhaps running a daily or weekly cron job could be the best frequence.
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Update repos and make a dry run for unattended-upgrades to evaluate whether
+# there are new security updates
+sudo apt-get update
+echo -e "Executing a dry-run for unattended-upgrades...\n"
+upgrades_status=$(sudo unattended-upgrades --dry-run -d | grep "All upgrades installed" | tee dry-run_log.txt)
+
+# Check unattended-upgrade output to evaluate if any updates are available
+if [ -z "$upgrades_status" ]; then
+    echo -e "No packages found that can be upgraded unattended and no pending auto-removals\n"
+
+elif [ -n "$upgrades_status" ] && [ "$upgrades_status" == "All upgrades installed" ]; then
+    echo -e "\nNew Security Updates Are Available. Proceeding to install them...\n"
+    sudo unattended-upgrades -d
+
+else
+    echo -e "Something went wrong while checking wheter unattended upgrades are available or not. Manual intervention is required.\n"
+
+fi

--- a/requirements.sh
+++ b/requirements.sh
@@ -4,8 +4,8 @@
 set -e
 
 echo "Ensure that APT works with HTTPS..."
-sudo apt-get update -y
-sudo apt-get install -y \
+sudo apt-get -qq update -y
+sudo apt-get -qq install -y \
   apt-transport-https \
   ca-certificates \
   software-properties-common \
@@ -25,7 +25,7 @@ echo "Add GlusterFS repo..."
 sudo add-apt-repository -y ppa:gluster/glusterfs-3.12
 
 echo "Updating Ubuntu..."
-sudo apt-get update -y
+sudo apt-get -qq update -y
 sudo DEBIAN_FRONTEND=noninteractive \
   apt-get -y \
   -o Dpkg::Options::="--force-confdef" \
@@ -84,4 +84,4 @@ sudo docker pull gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:$kube_dns_
 sudo docker pull quay.io/coreos/flannel:$flannel_version-amd64
 
 # After having installed all the necessary packages, we check whether there are related security-updates
-sudo apt-get update -y && sudo unattended-upgrades -d
+sudo apt-get -qq update -y && sudo unattended-upgrades -d

--- a/requirements.sh
+++ b/requirements.sh
@@ -9,8 +9,7 @@ sudo apt-get install -y \
   apt-transport-https \
   ca-certificates \
   software-properties-common \
-  curl \
-  unattended-upgrades
+  curl
 
 echo "Add Kubernetes repo..."
 sudo sh -c 'curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -'
@@ -83,3 +82,6 @@ sudo docker pull gcr.io/google_containers/k8s-dns-sidecar-amd64:$kube_dns_versio
 sudo docker pull gcr.io/google_containers/k8s-dns-kube-dns-amd64:$kube_dns_version
 sudo docker pull gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:$kube_dns_version
 sudo docker pull quay.io/coreos/flannel:$flannel_version-amd64
+
+# After having installed all the necessary packages, we check whether there are related security-updates
+sudo apt-get update -y && sudo unattended-upgrades -d


### PR DESCRIPTION
## Change content and motivation
This PR wants to provide some basic features in order to check availability of new security updates (both default and kernels ones) and install them in our latest stable KubeNow image if need be. This check will be performed as part of a cron job set up in our Travis CI. 

Thus the general idea is the following:

Travis CI will check whether the build was triggered by a cron job. If so, then we will then start building an image by using our already existing latest stable (e.g. 050) instead of Ubuntu 16.04 as our source image for we do not need to reinstall all the requirements; on the contrary, we want to check if our latest built image requires any security updates to be performed (further details and comments can be found within the changed and added files).

<!-- ## GitHub cross-links -->
Fixes https://github.com/kubenow/KubeNow/issues/265
