### PR TITLE
Refactory AWS Tenancy Details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,9 @@ before_install:
       https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
       > /tmp/terraform.zip
   - unzip /tmp/terraform.zip -d /tmp/
-  - sudo pip install --upgrade pip
-  - sudo pip install yamllint=="${YAMLLINT_VERSION}"
-  - sudo apt-get -qq install shellcheck
+  - sudo pip install --upgrade -qq pip
+  - sudo pip install -qq yamllint=="${YAMLLINT_VERSION}"
+  - sudo apt-get -qq install shellcheck -y
 
   # Check Terraform
   - /tmp/terraform fmt bin/*.tf
@@ -99,6 +99,8 @@ install:
 
 before_script:
   # Check whether this build was triggered by our cron job for security-updates
+  # Note: in a yml file there seems to not be possible to have a space
+  # before a global variable within an echo string
   - echo "TRAVIS_EVENT_TYPE is:$TRAVIS_EVENT_TYPE"
   - >
     if [ "$TRAVIS_EVENT_TYPE" = 'cron' ]; then
@@ -119,14 +121,8 @@ before_script:
 
   # GCE login
   - echo $GCE_KEY > ./bin/account_file.json
-
-  - >
-      gcloud auth activate-service-account
-      12202776487-compute@developer.gserviceaccount.com
-      --key-file=$GCE_ACCOUNT_FILE_PATH
-  - >
-      gcloud auth login 12202776487-compute@developer.gserviceaccount.com
-      --project phenomenal-1145 -q
+  - gcloud auth activate-service-account 12202776487-compute@developer.gserviceaccount.com --key-file=$GCE_ACCOUNT_FILE_PATH
+  - gcloud auth login 12202776487-compute@developer.gserviceaccount.com --project phenomenal-1145 -q
 
 script:
   # Finally bulding the image with packer
@@ -146,10 +142,10 @@ after_success:
     fi
 
   # The below script used to be run as post-processor for the Openstack's builder.
-  # In order to avoid running Terraform within Packer, hence getting a cumbersome and tedious log output. travis_retry
+  # In order to avoid running Terraform within Packer, hence getting a cumbersome and tedious log output.
   - >
     if [ $HOST_CLOUD = 'openstack' ]; then
-        bin/os_pp.sh
+        travis_retry bin/os_pp.sh
     fi
 
 notifications:

--- a/bin/os_pp.sh
+++ b/bin/os_pp.sh
@@ -3,8 +3,8 @@
 
 # Installing needed tools
 # NB: this bash script run in travis where sudo is required. Thus we must put sudo before the usual pip command
-sudo pip install --upgrade pip
-sudo pip install python-glanceclient python-neutronclient
+sudo pip install --upgrade -qq pip
+sudo pip install -qq python-glanceclient python-neutronclient
 
 # Building the OS Instance
 cd ./bin || exit
@@ -57,10 +57,12 @@ export OS_TENANT_NAME=$OS_TENANT_NAME
 export OS_AUTH_VERSION=3
 export OS_POOL_NAME=$OS_POOL_NAME
 export OS_EXTERNAL_NET_UUUID=$OS_EXTERNAL_NET_UUUID
-# AWS credentials
+# AWS credentials and Buckets URLs
 export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
 export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
+export AWS_BUCKET1_URL=$AWS_BUCKET1_URL
+export AWS_BUCKET2_URL=$AWS_BUCKET2_URL
 " >>/tmp/aws_and_os.sh
 
 # Launching OS instance with terraform

--- a/bin/os_tf.sh
+++ b/bin/os_tf.sh
@@ -32,10 +32,12 @@ md5sum "$kubenow_image_name".qcow2 >"$kubenow_image_name".qcow2.md5
 
 # Uploading the new image format to the AWS S3 bucket. Previous copy will be overwritten.
 echo "Uploading new image format into AWS S3 bucket: kubenow-us-east-1 ..."
-aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
-aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-us-east-1 --region us-east-1 --acl public-read --quiet
+bucket1_region=$(echo "$AWS_BUCKET1_URL" | awk -F "/" '{{ print $2 $3 $4 }}' | sed -e 's/kubenow-//')
+aws s3 cp "$kubenow_image_name".qcow2 "$AWS_BUCKET1_URL" --region "$bucket1_region" --acl public-read --quiet
+aws s3 cp "$kubenow_image_name".qcow2.md5 "$AWS_BUCKET1_URL" --region "$bucket1_region" --acl public-read --quiet
 
 # Copy file to bucket in other aws region
-echo "Copying new image format into AWS S3 bucket: kubenow-us-central-1 ..."
-aws s3 cp "$kubenow_image_name".qcow2 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read --quiet
-aws s3 cp "$kubenow_image_name".qcow2.md5 s3://kubenow-eu-central-1/ --region us-east-1 --region eu-central-1 --acl public-read --quiet
+echo "Copying new image format into AWS S3 bucket: kubenow-eu-central-1 ..."
+bucket2_region=$(echo "$AWS_BUCKET2_URL" | awk -F "/" '{{ print $2 $3 $4 }}' | sed -e 's/kubenow-//')
+aws s3 cp "$kubenow_image_name".qcow2 "$AWS_BUCKET2_URL" --region "$bucket1_region" --region "$bucket2_region" --acl public-read --quiet
+aws s3 cp "$kubenow_image_name".qcow2.md5 "$AWS_BUCKET2_URL" --region "$bucket1_region" --region "$bucket2_region" --acl public-read --quiet

--- a/requirements.sh
+++ b/requirements.sh
@@ -33,7 +33,7 @@ sudo DEBIAN_FRONTEND=noninteractive \
   upgrade
 
 echo "Installing Kubernetes requirements..."
-sudo apt-get install -y \
+sudo apt-get -qq install -y \
   docker-engine=1.13.1-0~ubuntu-xenial \
   kubernetes-cni=0.6.0-00 \
   kubeadm=1.9.2-00 \
@@ -42,7 +42,7 @@ sudo apt-get install -y \
 
 echo "Installing other requirements..."
 # APT requirements
-sudo apt-get install -y \
+sudo apt-get -qq install -y \
   python \
   daemon \
   attr \


### PR DESCRIPTION
## Change content and motivation
We need to move the KubeNow Images to our new Phenomenal AWS tenancy. This PR provides the following:

- New buckets have been created firsts.
- All the old buckets URLs have been updated with new ones.
- New Buckets contains stable releases.
- Travis CI AWS env variables have been updated as well.
- The AWS packer builder is basically the same as only the value of env variables changed.
- All previous KubeNow AMIs moved across the two tenancies.
- New created images are correctly stored in the new tenancy.

Fixes: https://github.com/kubenow/KubeNow/issues/333