### PR TITLE
Fixing code for azure new gpg key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,8 +93,10 @@ install:
   - sudo apt-get -qq install google-cloud-sdk -y
 
   # Installing Azure command-line client here as used both in cleaning and cron_job scripts
-  - echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
+  - AZ_REPO=$(lsb_release -cs)
+  - echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
   - sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+  - curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
   - sudo apt-get -qq install apt-transport-https -y
   - sudo apt-get -qq update && sudo apt-get -qq install azure-cli -y
 


### PR DESCRIPTION
## Change content and motivation
As explained in the [azure's official documentation](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest), This signing key is deprecated, and has been replaced already. In order to keep getting updates with `apt`, we make sure that we also install the new key with:

`curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -`