### PR TITLE
Updating Openstack variables in Travis + Updating some deprecated features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 ---
-language: python # need for pip
+language: python
+
+python:
+  - "2.7"
+
+virtualenv:
+  system_site_packages: true
 
 sudo: required
 
@@ -8,7 +14,7 @@ services:
 
 env:
   global:
-    - TERRAFORM_VERSION=0.9.4
+    - TERRAFORM_VERSION=0.11.10
     - PACKER_VERSION=1.1.2
     - PIP=9.0.3
     # Workaround to build on google - See https://github.com/travis-ci/travis-ci/issues/7940
@@ -95,12 +101,13 @@ install:
   - sudo apt-get -qq install google-cloud-sdk -y
 
   # Installing Azure command-line client here as used both in cleaning and cron_job scripts
+  - sudo apt-get -qq install apt-transport-https lsb-release software-properties-common -y
   - AZ_REPO=$(lsb_release -cs)
   - echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
-  - sudo apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
-  - curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
-  - sudo apt-get -qq install apt-transport-https -y
-  - sudo apt-get -qq update && sudo apt-get -qq install azure-cli -y
+  - >
+    sudo apt-key --keyring /etc/apt/trusted.gpg.d/Microsoft.gpg adv \
+      --keyserver packages.microsoft.com --recv-keys BC528686B50D79E339D3721CEB3E94ADBE1229CF
+  - sudo apt-get update && sudo apt-get install azure-cli
 
 before_script:
   # Check whether this build was triggered by our cron job for security-updates

--- a/bin/os_pp.sh
+++ b/bin/os_pp.sh
@@ -3,52 +3,53 @@
 
 # Installing needed tools
 # NB: this bash script run in travis where sudo is required. Thus we must put sudo before the usual pip command
-sudo pip install python-openstackclient==3.11.0
+sudo -H pip install cryptography=="2.2.2"
+sudo -H pip install python-openstackclient=="3.17.0"
 
 # Building the OS Instance
 cd ./bin || exit
 
 # Environmental Variables for building with Terraform apply
+export TF_VAR_auth_url="$OS_AUTH_URL"
 export TF_VAR_username="$OS_USERNAME"
 export TF_VAR_password="$OS_PASSWORD"
-export TF_VAR_auth_url="$OS_AUTH_URL"
-export TF_VAR_user_domain_id="$OS_USER_DOMAIN_ID"
-export TF_VAR_domain_id="$OS_DOMAIN_ID"
+export TF_VAR_domain_name="$OS_DOMAIN_NAME"
+export TF_VAR_tenant_name="$OS_TENANT_NAME"
 export TF_VAR_region_name="$OS_REGION_NAME"
-export TF_VAR_project_id="$OS_PROJECT_ID"
-export TF_VAR_project_name="$OS_PROJECT_NAME"
 export TF_VAR_api_version="$OS_IDENTITY_API_VERSION"
 export TF_VAR_os_pool_name="$OS_POOL_NAME"
-export TF_VAR_ssh_key_pub="${HOME}/.ssh/id_rsa.pub"
+export TF_VAR_ssh_key_pub="../keys/id_rsa.pub"
+export TF_VAR_ssh_key_prv="../keys/id_rsa"
 export TF_VAR_current_version=$CURRENT_VERSION
 export TF_VAR_kubenow_image_name=$IMAGE_NAME
 
 # Parsing KubeNow image ID of newly crated one. \s option will look for exact match
-image_id=$(openstack image list | grep "\skubenow-$CURRENT_VERSION\s" | awk '{print $2}')
-export TF_VAR_kubenow_image_id=$image_id
+kn_image_id=$(openstack image list | grep "\skubenow-$CURRENT_VERSION\s" | awk '{print $2}')
+echo -e "Latest Kubenow image ID: $kn_image_id"
+export TF_VAR_kubenow_image_id=$kn_image_id
 
 # Parsing some needed values for spawning Openstack instance with terraform
 os_image_id=$(openstack image list | grep "Ubuntu 16.04 Xenial Xerus" | awk '{print $2}')
+echo -e "Ubuntu 16.04 Xenial Xerus image ID: $os_image_id"
 export TF_VAR_os_image_id=$os_image_id
 
+# Parsing default network id in our Openstack provider
 network_id=$(openstack network list | grep -i "default" | awk '{print $2}')
+echo -e "Default Network ID: $network_id"
 export TF_VAR_network_id=$network_id
 
 # Creating a credetianl file which will be provisioned via Terraform to an OS instance
 echo -e "
 #!/bin/bash
 # Openstack credentials and env variables
-export OS_PASSWORD=$OS_PASSWORD
-export OS_USERNAME=$OS_USERNAME
 export OS_AUTH_URL=$OS_AUTH_URL
-export OS_USER_DOMAIN_ID=$OS_USER_DOMAIN_ID
-export OS_DOMAIN_ID=$OS_DOMAIN_ID
+export OS_USERNAME=$OS_USERNAME
+export OS_PASSWORD=$OS_PASSWORD
+export OS_DOMAIN_NAME=$OS_DOMAIN_NAME
+export OS_TENANT_NAME=$OS_TENANT_NAME
 export OS_REGION_NAME=$OS_REGION_NAME
-export OS_PROJECT_ID=$OS_PROJECT_ID
-export OS_PROJECT_NAME=$OS_PROJECT_NAME
-export OS_IDENTITY_API_VERSION=3
-export OS_POOL_NAME=$OS_POOL_NAME
-export OS_EXTERNAL_NET_UUUID=$OS_EXTERNAL_NET_UUUID
+export OS_AUTH_VERSION=$OS_AUTH_VERSION
+export OS_IDENTITY_API_VERSION=$OS_IDENTITY_API_VERSION
 # AWS credentials and Buckets URLs
 export AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID
 export AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY
@@ -58,7 +59,7 @@ export AWS_BUCKET2_URL=$AWS_BUCKET2_URL
 " >>/tmp/aws_and_os.sh
 
 # Launching OS instance with terraform
-/tmp/terraform apply
+/tmp/terraform init && /tmp/terraform apply -auto-approve
 TF_STATUS="$?"
 
 # Destroying OS instance with terraform


### PR DESCRIPTION
Hello @andersla! As per our discussion, regularly tech companies do releases updates and various; hence a couple of things needed to be revised. Namely:

- Openstack global variables in Travis (i.e. CityCloud RC fields)
- Some python related glitches and packages versions
- Azure new GPG key for the apt package
- Terraform builder file for OS
- Removed unnecessary leftovers variables

Also please see files changed for further comments.